### PR TITLE
feat: typeorm model mapping

### DIFF
--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -16,7 +16,7 @@ export const AppDataSource = new DataSource({
     type: "postgres",
     // Tive que colocar várias opções secundárias de valor por causa da tipagem forte do TS
     host: process.env.DB_HOST || "localhost",
-    port: Number(process.env.DB_PORT) || 5433,
+    port: Number(process.env.DB_PORT || "5433"),
     username: process.env.DB_USER || "postgres",
     password: process.env.DB_PASSWORD || "",
     database: process.env.DB_NAME || "meu_banco" ,

--- a/src/models/admin.models.ts
+++ b/src/models/admin.models.ts
@@ -1,5 +1,7 @@
+import { Entity } from 'typeorm';
 import { Pessoa } from './pessoa.models.js'
 
+@Entity()
 export class Admin extends Pessoa {
     
 }

--- a/src/models/contato.models.ts
+++ b/src/models/contato.models.ts
@@ -1,11 +1,34 @@
+import { Column } from "typeorm";
+
 export class Contato{
 
+    @Column({type: "varchar"})
+    public telefone: string;
+
+    @Column({type: "varchar"})
+    public email: string;
+    
+    @Column({type: "varchar"})
+    public instagram?: string | undefined;
+
+    @Column({type: "varchar"})
+    public facebook?: string | undefined;
+
+    @Column({type: "varchar"})
+    public site?: string | undefined;
+
     constructor(
-        public telefone: string,
-        public email: string,
-        // abaixo, usei o ? ao final do atributo para definir a possibilidade de ser undefined
-        public instagram?: string | undefined,
-        public facebook?: string | undefined,
-        public site?: string | undefined,
-    ){}
+        telefone: string,
+        email: string,
+        instagram: string | undefined,
+        facebook: string | undefined,
+        site: string | undefined,
+    ){
+
+        this.telefone = telefone;
+        this.email = email;
+        this.instagram = instagram;
+        this.facebook = facebook;
+        this.site = site;
+    }
 }

--- a/src/models/endereco.model.ts
+++ b/src/models/endereco.model.ts
@@ -1,11 +1,40 @@
+import { Column } from "typeorm";
+
 export class Endereco { 
 
+    @Column({type: "varchar"})
+    public logradouro: string;
+
+    @Column({type: "varchar"})
+    public bairro: string;
+
+    @Column({type: "long"})
+    public numero: number;
+
+    @Column({type: "varchar"})
+    public cep: string;
+
+    @Column({type: "varchar", length: 2})
+    public estado: string;
+
+    @Column({type: "varchar"})
+    public pais: string;
+
     constructor(
-        public logradouro: string,
-        public bairro: string,
-        public numero: number,
-        public cep: string,
-        public estado: string,
-        public pais: string
-    ){}
+        logradouro: string,
+        bairro: string,
+        numero: number,
+        cep: string,
+        estado: string,
+        pais: string,
+    ){
+
+        this.logradouro = logradouro;
+        this.bairro =  bairro;
+        this.numero =  numero;
+        this.cep =  cep;
+        this.estado =  estado;
+        this.pais =  pais;
+
+    }
 }

--- a/src/models/instituicao.model.ts
+++ b/src/models/instituicao.model.ts
@@ -1,5 +1,6 @@
-import type { Endereco } from './endereco.model.js';
-import type { Contato } from './contato.models.js';
+import { Endereco } from './endereco.model.js';
+import { Contato } from './contato.models.js';
+import { Column, Entity } from 'typeorm';
 
 // funcinoa como um enum. O "as const" impede alterações
 const Status = {
@@ -8,19 +9,55 @@ const Status = {
     PENDENTE: "pendente"
 } as const;
 
+@Entity()
 export class Instituicao {   
     
-    constructor(
-        public nome: string,
-        public servicos: string[],
-        public contato: Contato,
-        public endereco: Endereco,
-        public cnpj?: string | undefined,
-        public readonly id?: bigint | undefined,
-        public readonly uuid?: string | undefined        
-    ){ 
+    @Column({type: "long"})
+    public readonly id?: bigint | undefined;
 
-        if(!(this.cnpj === undefined)) this.validaCnpj(this.cnpj);
+    @Column({type: "varchar"})
+    public readonly uuid;
+    
+    @Column({type: "varchar"})
+    public nome?: string;
+
+    @Column({type: "array"})
+    public servicos?: string[];
+
+    @Column({type: "varchar"})
+    public cnpj?: string | undefined;
+    
+    @Column(() => Contato)
+    public contato?: Contato;
+
+    @Column(() => Endereco)
+    public endereco?: Endereco;
+
+    constructor(
+        nome?: string,
+        servicos?: string[],
+        contato?: Contato,
+        endereco?: Endereco,
+        cnpj?: string | undefined,
+        id?: bigint | undefined,
+        uuid?: string | undefined        
+    ){ 
+        if(nome && servicos && contato && endereco){
+            
+            if(!(cnpj === undefined)) {
+
+                if(this.validaCnpj(cnpj)) throw new Error("Não é possível criar Instituicao: CNPJ inválido");
+            }
+
+            this.nome = nome;
+            this.servicos = servicos;
+            this.contato = contato;
+            this.endereco = endereco;
+            this.cnpj = cnpj;
+            this.id = id;
+            this.uuid = uuid;
+
+        }
     }
 
     private validaCnpj(cnpj: string): boolean {

--- a/src/models/pessoa.models.ts
+++ b/src/models/pessoa.models.ts
@@ -1,19 +1,55 @@
+import { Column, Entity, PrimaryColumn, PrimaryGeneratedColumn } from "typeorm";
 import { Endereco } from "./endereco.model.js";
 
 export class Pessoa {
     
+    @PrimaryGeneratedColumn("increment")
+    public id?: bigint;
+
+    @Column({type: "varchar", nullable: false})
+    public uuid?: string;
+
+    @Column({ type: "varchar", length: 255 })
+    public nome?: string;
+
+    @Column({ type: "varchar", length: 11 })
+    public cpf?: string;
+
+    @Column({ type: "varchar" })
+    public email?: string;
+
+    @Column({ type: "varchar"})
+    public senhaHash?: string;
+
+    // Essa expressão abaixo faz essa Entity aqui criar colunas usando o mapeamento de colunas da CLasse Endereco.
+    // então a classe Pessoa faria colunas do tipo: EnderecoNumero, EndereroPais, etc...
+    @Column(() => Endereco)
+    public endereco?: Endereco;
+
     constructor(
-        public nome: string,
-        public cpf: string,
-        public email: string,
-        public senhaHash: string,
-        public id?: bigint,
-        public uuid?: string,
-        public endereco?: Endereco
+        nome?: string,
+        cpf?: string,
+        email?: string,
+        senhaHash?: string,
+        id?: bigint,
+        uuid?: string,
+        endereco?: Endereco
     ){ 
-        if (!this.validaCpf(this.cpf)) throw new Error("Não é possível criar Pessoa: CPF inválido");
-        if (!this.email.includes("@")) throw new Error("Não é possível criar Pessoa: Email inválido");
-        if (this.senhaHash.trim().length === 0) throw new Error("Não é possível criar Pessoa: Senha vazia");
+        if(nome && cpf && email && senhaHash){
+            if (!this.validaCpf(cpf)) throw new Error("Não é possível criar Pessoa: CPF inválido");
+            if (!email.includes("@")) throw new Error("Não é possível criar Pessoa: Email inválido");
+            if (senhaHash.trim().length === 0) throw new Error("Não é possível criar Pessoa: Senha vazia");
+            
+            this.nome = nome;
+            this.cpf = cpf;
+            this.email = email;
+            this.senhaHash = senhaHash;
+            
+            this.id =  id;
+            this.uuid =  uuid;
+            this.endereco =  endereco;
+        }
+
     }
 
     private validaCpf(cpf: string): boolean {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,7 +29,7 @@
 
     // Stricter Typechecking Options
     "noUncheckedIndexedAccess": true,
-    "exactOptionalPropertyTypes": true,
+    "exactOptionalPropertyTypes": false,
 
     // Style Options
     // "noImplicitReturns": true,


### PR DESCRIPTION
Essa branch adiciona os Decorators do TypeORM nas models. Com eles, o framework conseguirá mapear as entidades e os campos que precisam ser persistidos.
Além disso, a opção exactOptionalPropertyTypes foi desabilitada porque o TypeORM pode instanciar entidades passando undefined para alguns parâmetros durante a construção dos objetos. Com essa configuração desligada, o projeto mantém compatibilidade com esse comportamento do framework sem gerar erros de tipagem desnecessários.

Após essa adição, o próximo passo é criar os métodos de interação com o banco e testar a conexão.

